### PR TITLE
avoid leaving dangling children by killing spawned processes

### DIFF
--- a/src/spawn.c
+++ b/src/spawn.c
@@ -299,7 +299,8 @@ spawn_kill(pid_t pid, int sig)
       if(s->pid == pid)
         break;
     if (s) {
-      r = kill(pid, sig);
+      /* kill the whole process group */
+      r = kill(-pid, sig);
       if (r < 0)
         r = -errno;
     }
@@ -494,7 +495,14 @@ spawn_and_give_stdout(const char *prog, char *argv[], char *envp[],
 
   *rd = fd[0];
   if (pid)
+  {
     *pid = p;
+
+    // make the spawned process a session leader so killing the 
+    // process group recursively kills any child process that 
+    // might have been spawned
+    setpgid(p, p);
+  }
   return 0;
 }
 


### PR DESCRIPTION
recursively